### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,7 +3,7 @@
 #######################################
 
 Velleman_K1200	KEYWORD1
-watchstates KEYWORD1
+watchstates	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
@@ -19,7 +19,7 @@ clearArrays	KEYWORD2
 notShowingTime KEYWORD2
 configureTime	KEYWORD2
 sleep	KEYWORD2
-isButtonPressed KEYWORD2
+isButtonPressed	KEYWORD2
 setHand	KEYWORD2
 setAllLeds	KEYWORD2
 setBeginAnimation	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords