### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,7 @@ setTime	KEYWORD2
 showArray	KEYWORD2
 showClock	KEYWORD2
 clearArrays	KEYWORD2
-notShowingTime KEYWORD2
+notShowingTime	KEYWORD2
 configureTime	KEYWORD2
 sleep	KEYWORD2
 isButtonPressed	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords