### PR TITLE
Remove invalid line from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -25,7 +25,6 @@ setAllLeds	KEYWORD2
 setBeginAnimation	KEYWORD2
 setEndAnimation	KEYWORD2
 addGame	KEYWORD2
-executeGame
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The executeGame keyword definition was missing the keywords identifier. Since this is a private function, it doesn't make sense to define it as a keyword anyway.